### PR TITLE
Fix warning about cti_files being deprecated

### DIFF
--- a/src/harvesters_gui/frontend/pyqt5.py
+++ b/src/harvesters_gui/frontend/pyqt5.py
@@ -148,7 +148,7 @@ class Harvester(QMainWindow):
 
     @property
     def cti_files(self):
-        return self.harvester_core.cti_files
+        return self.harvester_core.files
 
     @property
     def harvester_core(self):


### PR DESCRIPTION
harvesters-gui currently prints this warning to the console when it starts:

```
harvesters_gui\frontend\pyqt5.py:163: DeprecationWarning: please consider to use files instead of cti_files.
  return self.harvester_core.cti_files
```

Apply the suggested fix to suppress the warning.