### PR TITLE
Fix QCssParser::parseColorValue warnings about alpha channel

### DIFF
--- a/src/harvesters_gui/_private/frontend/pyqt5/about.py
+++ b/src/harvesters_gui/_private/frontend/pyqt5/about.py
@@ -57,7 +57,7 @@ class TransparentLineEdit(QLineEdit):
 
         self.setReadOnly(True)
         self.setFont(get_system_font())
-        self.setStyleSheet('background: rgb(0, 0, 0, 0%)')
+        self.setStyleSheet('background: rgba(0, 0, 0, 0%)')
         self.setFrame(False)
 
 
@@ -68,7 +68,7 @@ class TransparentTextEdit(QTextEdit):
 
         self.setReadOnly(True)
         self.setFont(get_system_font())
-        self.setStyleSheet('background: rgb(0, 0, 0, 0%)')
+        self.setStyleSheet('background: rgba(0, 0, 0, 0%)')
         self.setLineWrapMode(True)
         self.setFrameStyle(QFrame.NoFrame)
         self.setAlignment(Qt.AlignCenter)


### PR DESCRIPTION
harvesters-gui currently prints this warning to the console when it starts:

```
WARNING: QCssParser::parseColorValue: Specified color without alpha value but alpha given: 'rgb 0, 0, 0, 0%'
```

Set the style sheet background property with `rgba` to fix the warning (explicitly sets the alpha channel).